### PR TITLE
Adjust targetContentOffset in scrollViewWillEndDragging

### DIFF
--- a/class/NPInfiniteScrollView.h
+++ b/class/NPInfiniteScrollView.h
@@ -9,5 +9,7 @@
 #import <UIKit/UIKit.h>
 
 @interface NPInfiniteScrollView : UIScrollView
-
+// Redraws the subview placeholders.  If your subviews are redrawn after insertion (eg loading
+// a UIImageView from the web), you should call this method to update their placeholders.
+-(void) redrawPlaceHolders;
 @end

--- a/class/NPInfiniteScrollView.m
+++ b/class/NPInfiniteScrollView.m
@@ -25,7 +25,7 @@
     BOOL hasHorizontalScroll;
     BOOL hasVerticalScroll;
     
-    id <UIScrollViewDelegate> originalDelegate;
+    __weak id <UIScrollViewDelegate> originalDelegate;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder

--- a/class/NPInfiniteScrollView.m
+++ b/class/NPInfiniteScrollView.m
@@ -17,9 +17,6 @@
 #endif
 
 @interface NPInfiniteScrollView () <UIScrollViewDelegate>
-
--(void) redrawPlaceHolders;
-
 @end
 
 @implementation NPInfiniteScrollView {

--- a/class/NPInfiniteScrollView.m
+++ b/class/NPInfiniteScrollView.m
@@ -281,24 +281,28 @@
         if (((*targetContentOffset).x<-self.frame.size.width/2)) {
             NPLog(@"decelerating backwards %@, %@", NSStringFromCGPoint((*targetContentOffset)), NSStringFromCGSize(self.contentSize));
             [super setContentOffset:CGPointMake(self.contentOffset.x+self.contentSize.width, self.contentOffset.y)];
+            targetContentOffset->x += self.contentSize.width;
         }
         
         //If target offset is far right
         if ((*targetContentOffset).x>self.contentSize.width-self.frame.size.width/2) {
             NPLog(@"decelerating forwards %@, %@", NSStringFromCGPoint((*targetContentOffset)), NSStringFromCGSize(self.contentSize));
             [super setContentOffset:CGPointMake(self.contentOffset.x-self.contentSize.width, self.contentOffset.y)];
+            targetContentOffset->x -= self.contentSize.width;
         }
         
         //If target offset is far up
         if (((*targetContentOffset).y<-self.frame.size.height/2)) {
             NPLog(@"decelerating upwards %@, %@", NSStringFromCGPoint((*targetContentOffset)), NSStringFromCGSize(self.contentSize));
             [super setContentOffset:CGPointMake(self.contentOffset.x, self.contentOffset.y+self.contentSize.height)];
+            targetContentOffset->y += self.contentSize.height;
         }
         
         //If target offset is far bottom
         if (((*targetContentOffset).y>self.contentSize.height-self.frame.size.height/2)) {
             NPLog(@"decelerating backwards %@, %@", NSStringFromCGPoint((*targetContentOffset)), NSStringFromCGSize(self.contentSize));
             [super setContentOffset:CGPointMake(self.contentOffset.x, self.contentOffset.y-self.contentSize.height)];
+            targetContentOffset->y -= self.contentSize.height;
         }
         
     }


### PR DESCRIPTION
Hi - while dragging slowly across the boundary of 'real subviews' to 'placeholder subviews', I'd often manage to take my finger off the screen and the scrollview would continue scrolling very slowly without decelerating.  Adjusting the targetContentOffset into the same range as the contentSize seems to fix this - what do you think?

This PR also includes a fix where the you might have a retain cycle between scrollview and its delegate, and makes `redrawPlaceHolders` a public method because I needed to update the placeholders after loading images from the web.  If you like I can break them into a separate PR.
